### PR TITLE
feat(telegram): add Telegram notifications for scooter events

### DIFF
--- a/internal/models/types.go
+++ b/internal/models/types.go
@@ -48,6 +48,7 @@ type Config struct {
 	Telemetry   TelemetryConfig    `yaml:"telemetry"`
 	Events      EventsConfig       `yaml:"events,omitempty"`
 	Commands    map[string]Command `yaml:"commands"`
+	Telegram    TelegramConfig     `yaml:"telegram,omitempty"`
 	UnuUplink   UnuUplinkConfig    `yaml:"unu_uplink,omitempty"`
 	ServiceName string             `yaml:"service_name,omitempty"`
 	Debug       bool               `yaml:"debug,omitempty"`
@@ -57,6 +58,7 @@ type Config struct {
 type ScooterConfig struct {
 	Identifier string `yaml:"identifier"`
 	Token      string `yaml:"token"`
+	Name       string `yaml:"name,omitempty"`
 }
 
 // MQTTConfig contains MQTT configuration
@@ -100,6 +102,16 @@ type EventsConfig struct {
 	Enabled    bool   `yaml:"enabled"`
 	BufferPath string `yaml:"buffer_path,omitempty"`
 	MaxRetries int    `yaml:"max_retries,omitempty"`
+}
+
+// TelegramConfig contains Telegram notification configuration
+type TelegramConfig struct {
+	Enabled   bool            `yaml:"enabled"`
+	BotToken  string          `yaml:"bot_token"`
+	ChatID    string          `yaml:"chat_id"`
+	Events    map[string]bool `yaml:"events,omitempty"`
+	RateLimit string          `yaml:"rate_limit,omitempty"`
+	QueueSize int             `yaml:"queue_size,omitempty"`
 }
 
 // BufferConfig contains telemetry buffer configuration

--- a/internal/telegram/notifier.go
+++ b/internal/telegram/notifier.go
@@ -1,0 +1,220 @@
+package telegram
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"net/url"
+	"sync"
+	"time"
+
+	"radio-gaga/internal/events"
+	"radio-gaga/internal/models"
+)
+
+// Notifier sends Telegram notifications for scooter events
+type Notifier struct {
+	config     *models.TelegramConfig
+	identifier string
+	name       string
+	queue      chan events.Event
+	client     *http.Client
+	rateLimit  time.Duration
+	cancel     context.CancelFunc
+	wg         sync.WaitGroup
+}
+
+// NewNotifier creates a new Telegram notifier
+func NewNotifier(config *models.TelegramConfig, scooterConfig *models.ScooterConfig) (*Notifier, error) {
+	rateLimit, err := time.ParseDuration(config.RateLimit)
+	if err != nil {
+		return nil, fmt.Errorf("invalid rate_limit: %v", err)
+	}
+
+	return &Notifier{
+		config:     config,
+		identifier: scooterConfig.Identifier,
+		name:       scooterConfig.Name,
+		queue:      make(chan events.Event, config.QueueSize),
+		client:     &http.Client{Timeout: 10 * time.Second},
+		rateLimit:  rateLimit,
+	}, nil
+}
+
+// Start begins processing the notification queue
+func (n *Notifier) Start(ctx context.Context) {
+	ctx, n.cancel = context.WithCancel(ctx)
+	n.wg.Add(1)
+	go n.processQueue(ctx)
+	log.Printf("[Telegram] Notifier started (rate_limit=%s, queue_size=%d)", n.rateLimit, n.config.QueueSize)
+}
+
+// Stop gracefully shuts down the notifier
+func (n *Notifier) Stop() {
+	if n.cancel != nil {
+		n.cancel()
+	}
+	n.wg.Wait()
+	log.Println("[Telegram] Notifier stopped")
+}
+
+// Notify enqueues an event for sending (non-blocking)
+func (n *Notifier) Notify(event events.Event) {
+	select {
+	case n.queue <- event:
+	default:
+		log.Printf("[Telegram] Queue full, dropping event: %s", event.EventType)
+	}
+}
+
+// ShouldNotify checks whether notifications are enabled for an event type
+func (n *Notifier) ShouldNotify(eventType string) bool {
+	if enabled, ok := n.config.Events[eventType]; ok {
+		return enabled
+	}
+	return false
+}
+
+func (n *Notifier) processQueue(ctx context.Context) {
+	defer n.wg.Done()
+	ticker := time.NewTicker(n.rateLimit)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case event := <-n.queue:
+			if err := n.sendToTelegram(event); err != nil {
+				log.Printf("[Telegram] Failed to send: %v", err)
+			}
+			// Rate limit: wait for next tick before processing more
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+			}
+		}
+	}
+}
+
+func (n *Notifier) sendToTelegram(event events.Event) error {
+	text := n.FormatMessage(event)
+	apiURL := fmt.Sprintf("https://api.telegram.org/bot%s/sendMessage", n.config.BotToken)
+
+	resp, err := n.client.PostForm(apiURL, url.Values{
+		"chat_id":    {n.config.ChatID},
+		"text":       {text},
+		"parse_mode": {"HTML"},
+	})
+	if err != nil {
+		return fmt.Errorf("HTTP request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("Telegram API returned status %d", resp.StatusCode)
+	}
+
+	log.Printf("[Telegram] Sent %s notification", event.EventType)
+	return nil
+}
+
+// FormatMessage formats an event into a concise one-line style message for Telegram
+func (n *Notifier) FormatMessage(event events.Event) string {
+	scooter := n.name
+	if scooter == "" {
+		scooter = n.identifier
+	}
+
+	d := event.Data
+	str := func(key string) string {
+		if v, ok := d[key]; ok && v != nil {
+			return fmt.Sprintf("%v", v)
+		}
+		return ""
+	}
+
+	switch event.EventType {
+	case events.EventTypeAlarm:
+		switch event.Status {
+		case "armed":
+			return fmt.Sprintf("🔒 %s alarm armed", scooter)
+		case "disarmed":
+			return fmt.Sprintf("🔓 %s alarm disarmed", scooter)
+		case "triggered":
+			return fmt.Sprintf("🚨 %s alarm triggered!", scooter)
+		default:
+			return fmt.Sprintf("🚨 %s alarm: %s", scooter, event.Status)
+		}
+
+	case events.EventTypeUnauthorizedMovement:
+		msg := fmt.Sprintf("⚠️ %s is moving while parked", scooter)
+		if s := str("gps_speed"); s != "" {
+			msg += fmt.Sprintf(" (%s km/h)", s)
+		}
+		return msg
+
+	case events.EventTypeBatteryWarning:
+		battery := formatBatteryName(str("battery"))
+		charge := str("charge")
+		return fmt.Sprintf("🔋 %s %s at %s%%", scooter, battery, charge)
+
+	case events.EventTypeTemperatureWarning:
+		component := formatComponentName(str("component"))
+		temp := str("temperature")
+		return fmt.Sprintf("🌡️ %s %s at %s°C", scooter, component, temp)
+
+	case events.EventTypeStateChange:
+		return fmt.Sprintf("🔄 %s: %s → %s", scooter, str("from"), str("to"))
+
+	case events.EventTypeConnectivity:
+		if event.Status == events.StatusLost {
+			return fmt.Sprintf("📡 %s lost internet", scooter)
+		}
+		return fmt.Sprintf("📡 %s back online", scooter)
+
+	case events.EventTypeFault:
+		if str("type") == "nrf_reset" {
+			return fmt.Sprintf("⚙️ %s NRF reset (reason: %s, count: %s)", scooter, str("reason"), str("count"))
+		}
+		desc := str("description")
+		if desc != "" {
+			return fmt.Sprintf("⚙️ %s fault: %s", scooter, desc)
+		}
+		return fmt.Sprintf("⚙️ %s fault: group %s, code %s", scooter, str("group"), str("code"))
+
+	default:
+		if event.Status != "" {
+			return fmt.Sprintf("📢 %s %s: %s", scooter, event.EventType, event.Status)
+		}
+		return fmt.Sprintf("📢 %s %s", scooter, event.EventType)
+	}
+}
+
+func formatBatteryName(key string) string {
+	switch key {
+	case "battery:0":
+		return "Battery 1"
+	case "battery:1":
+		return "Battery 2"
+	case "cb-battery":
+		return "CB battery"
+	default:
+		return key
+	}
+}
+
+func formatComponentName(key string) string {
+	switch key {
+	case "engine-ecu":
+		return "Engine"
+	case "battery:0":
+		return "Battery 1"
+	case "battery:1":
+		return "Battery 2"
+	default:
+		return key
+	}
+}

--- a/internal/telegram/notifier_test.go
+++ b/internal/telegram/notifier_test.go
@@ -1,0 +1,238 @@
+package telegram
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"radio-gaga/internal/events"
+	"radio-gaga/internal/models"
+)
+
+func testConfig() *models.TelegramConfig {
+	return &models.TelegramConfig{
+		Enabled:   true,
+		BotToken:  "test-token",
+		ChatID:    "12345",
+		RateLimit: "10ms",
+		QueueSize: 10,
+		Events: map[string]bool{
+			"alarm":                 true,
+			"unauthorized_movement": true,
+			"battery_warning":       true,
+			"temperature_warning":   true,
+			"state_change":          false,
+		},
+	}
+}
+
+func testScooter() *models.ScooterConfig {
+	return &models.ScooterConfig{
+		Identifier: "TEST-VIN",
+		Name:       "Test Scooter",
+	}
+}
+
+func TestShouldNotify(t *testing.T) {
+	n, err := NewNotifier(testConfig(), testScooter())
+	if err != nil {
+		t.Fatalf("NewNotifier: %v", err)
+	}
+
+	tests := []struct {
+		eventType string
+		expected  bool
+	}{
+		{"alarm", true},
+		{"unauthorized_movement", true},
+		{"battery_warning", true},
+		{"temperature_warning", true},
+		{"state_change", false},
+		{"unknown_event", false},
+	}
+
+	for _, tt := range tests {
+		if got := n.ShouldNotify(tt.eventType); got != tt.expected {
+			t.Errorf("ShouldNotify(%q) = %v, want %v", tt.eventType, got, tt.expected)
+		}
+	}
+}
+
+func TestFormatAlarmArmed(t *testing.T) {
+	n, _ := NewNotifier(testConfig(), &models.ScooterConfig{
+		Identifier: "WUNU2S3B7MZ000147",
+		Name:       "Deep Blue",
+	})
+
+	msg := n.FormatMessage(events.NewEvent(events.EventTypeAlarm, "armed", nil))
+	assertEq(t, msg, "🔒 Deep Blue alarm armed")
+}
+
+func TestFormatAlarmDisarmed(t *testing.T) {
+	n, _ := NewNotifier(testConfig(), testScooter())
+	msg := n.FormatMessage(events.NewEvent(events.EventTypeAlarm, "disarmed", nil))
+	assertEq(t, msg, "🔓 Test Scooter alarm disarmed")
+}
+
+func TestFormatAlarmTriggered(t *testing.T) {
+	n, _ := NewNotifier(testConfig(), testScooter())
+	msg := n.FormatMessage(events.NewEvent(events.EventTypeAlarm, "triggered", nil))
+	assertEq(t, msg, "🚨 Test Scooter alarm triggered!")
+}
+
+func TestFormatBatteryWarning(t *testing.T) {
+	n, _ := NewNotifier(testConfig(), testScooter())
+	event := events.NewEvent(events.EventTypeBatteryWarning, "triggered", map[string]interface{}{
+		"battery": "battery:0",
+		"charge":  5,
+	})
+	msg := n.FormatMessage(event)
+	assertEq(t, msg, "🔋 Test Scooter Battery 1 at 5%")
+}
+
+func TestFormatTemperatureWarning(t *testing.T) {
+	n, _ := NewNotifier(testConfig(), testScooter())
+	event := events.NewEvent(events.EventTypeTemperatureWarning, "triggered", map[string]interface{}{
+		"component":   "engine-ecu",
+		"temperature": 85,
+	})
+	msg := n.FormatMessage(event)
+	assertEq(t, msg, "🌡️ Test Scooter Engine at 85°C")
+}
+
+func TestFormatStateChange(t *testing.T) {
+	n, _ := NewNotifier(testConfig(), testScooter())
+	event := events.NewEvent(events.EventTypeStateChange, "", map[string]interface{}{
+		"from": "standby",
+		"to":   "driving",
+	})
+	msg := n.FormatMessage(event)
+	assertEq(t, msg, "🔄 Test Scooter: standby → driving")
+}
+
+func TestFormatConnectivity(t *testing.T) {
+	n, _ := NewNotifier(testConfig(), testScooter())
+
+	lost := n.FormatMessage(events.NewEvent(events.EventTypeConnectivity, events.StatusLost, nil))
+	assertEq(t, lost, "📡 Test Scooter lost internet")
+
+	restored := n.FormatMessage(events.NewEvent(events.EventTypeConnectivity, events.StatusRegained, nil))
+	assertEq(t, restored, "📡 Test Scooter back online")
+}
+
+func TestFormatUnauthorizedMovement(t *testing.T) {
+	n, _ := NewNotifier(testConfig(), testScooter())
+	event := events.NewEvent(events.EventTypeUnauthorizedMovement, "triggered", map[string]interface{}{
+		"gps_speed":     12,
+		"vehicle_state": "standby",
+	})
+	msg := n.FormatMessage(event)
+	assertEq(t, msg, "⚠️ Test Scooter is moving while parked (12 km/h)")
+}
+
+func TestFormatFaultNrfReset(t *testing.T) {
+	n, _ := NewNotifier(testConfig(), testScooter())
+	event := events.NewEvent(events.EventTypeFault, "triggered", map[string]interface{}{
+		"type":   "nrf_reset",
+		"reason": "0x4",
+		"count":  3,
+	})
+	msg := n.FormatMessage(event)
+	assertEq(t, msg, "⚙️ Test Scooter NRF reset (reason: 0x4, count: 3)")
+}
+
+func TestFormatWithoutName(t *testing.T) {
+	n, _ := NewNotifier(testConfig(), &models.ScooterConfig{
+		Identifier: "WUNU2S3B7MZ000147",
+	})
+	msg := n.FormatMessage(events.NewEvent(events.EventTypeAlarm, "armed", nil))
+	assertEq(t, msg, "🔒 WUNU2S3B7MZ000147 alarm armed")
+}
+
+func TestNotifyQueueFull(t *testing.T) {
+	cfg := testConfig()
+	cfg.QueueSize = 1
+	n, err := NewNotifier(cfg, testScooter())
+	if err != nil {
+		t.Fatalf("NewNotifier: %v", err)
+	}
+
+	event := events.NewEvent(events.EventTypeAlarm, "triggered", nil)
+	n.Notify(event)
+	n.Notify(event)
+
+	if len(n.queue) != 1 {
+		t.Errorf("queue should have 1 event, got %d", len(n.queue))
+	}
+}
+
+func TestSendToTelegram(t *testing.T) {
+	var receivedCount int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&receivedCount, 1)
+		if r.Method != "POST" {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("ParseForm: %v", err)
+		}
+		if r.FormValue("chat_id") != "12345" {
+			t.Errorf("unexpected chat_id: %s", r.FormValue("chat_id"))
+		}
+		if r.FormValue("parse_mode") != "HTML" {
+			t.Errorf("unexpected parse_mode: %s", r.FormValue("parse_mode"))
+		}
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{"ok":true}`)
+	}))
+	defer server.Close()
+
+	n, _ := NewNotifier(testConfig(), testScooter())
+	n.client = server.Client()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	n.Start(ctx)
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	n.Stop()
+}
+
+func TestStartStop(t *testing.T) {
+	n, _ := NewNotifier(testConfig(), testScooter())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	n.Start(ctx)
+	n.Notify(events.NewEvent(events.EventTypeAlarm, "triggered", nil))
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	n.Stop()
+}
+
+func TestInvalidRateLimit(t *testing.T) {
+	cfg := testConfig()
+	cfg.RateLimit = "not-a-duration"
+
+	_, err := NewNotifier(cfg, testScooter())
+	if err == nil {
+		t.Error("expected error for invalid rate_limit")
+	}
+}
+
+func assertEq(t *testing.T, got, want string) {
+	t.Helper()
+	if got != want {
+		t.Errorf("got:  %q\nwant: %q", got, want)
+	}
+}
+
+func assertContains(t *testing.T, s, substr string) {
+	t.Helper()
+	if !strings.Contains(s, substr) {
+		t.Errorf("expected %q to contain %q", s, substr)
+	}
+}

--- a/radio-gaga.example.yml
+++ b/radio-gaga.example.yml
@@ -89,6 +89,25 @@ commands:
     disabled: false
   open_seatbox:
     disabled: false
+# Telegram notifications (optional)
+# Sends alerts directly to a Telegram chat via the Bot API
+# Create a bot via @BotFather, get chat_id by messaging the bot
+# and calling https://api.telegram.org/bot<token>/getUpdates
+# telegram:
+#   enabled: true
+#   bot_token: "YOUR_BOT_TOKEN"
+#   chat_id: "YOUR_CHAT_ID"
+#   rate_limit: 1s
+#   queue_size: 100
+#   events:
+#     alarm: true
+#     unauthorized_movement: true
+#     battery_warning: true
+#     temperature_warning: true
+#     state_change: false
+#     connectivity: false
+#     fault: false
+
 # unu-uplink reconfiguration (optional)
 # If enabled, radio-gaga will reconfigure mdb-uplink-service to use the same
 # MQTT broker and CA certificate as radio-gaga, then restart the service.


### PR DESCRIPTION
## Summary

Sends Telegram alerts directly from radio-gaga when scooter events fire — alarm state changes, unauthorized movement, battery/temperature warnings, state transitions, connectivity, and faults. Each scooter configures its own bot token and chat ID. Non-blocking queue with rate limiting so Telegram failures never affect MQTT event publishing.

## Changes

- `EventListener` interface on the event detector for pluggable notification backends
- Telegram notifier with per-event formatting, e.g. `🔒 Deep Blue alarm armed`, `⚠️ Void Crow is moving while parked (12 km/h)`
- Alarm detection moved from client to event detector, reading status from Redis hash instead of pub/sub payload
- Vehicle state change tracking (separate from power-manager state)
- Unauthorized movement detection (GPS speed > 0 while vehicle parked/locked)
- Scooter `name` config field for human-friendly labels in notifications
- `internet:signal-quality` added to noisy telemetry fields (fluctuates constantly, doesn't need priority flushing)

## Configuration

```yaml
scooter:
  name: Deep Blue        # optional, falls back to identifier

telegram:
  enabled: true
  bot_token: "YOUR_BOT_TOKEN"
  chat_id: "YOUR_CHAT_ID"
  rate_limit: 1s
  queue_size: 100
  events:
    alarm: true
    unauthorized_movement: true
    battery_warning: true
    temperature_warning: true
    state_change: false
```