### PR TITLE
feat(telemetry): report hop-on as stand-by to cloud

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -1028,10 +1028,20 @@ func (s *ScooterMQTTClient) publishTelemetry() {
 
 			switch msg.Channel {
 			case "vehicle":
-				currentVehicleState, err := s.redisClient.HGet(s.ctx, "vehicle", "state").Result()
+				// Read both state and hop-on-active so we can detect the
+				// effective (cloud-facing) state: while hop-on-active=true
+				// vehicle-service publishes state="parked", but we report
+				// "stand-by" to match GetTelemetryFromRedis.
+				vehicleFields, err := s.redisClient.HMGet(s.ctx, "vehicle", "state", "hop-on-active").Result()
 				if err != nil {
 					log.Printf("Error getting vehicle state from Redis: %v", err)
 					continue
+				}
+				rawState, _ := vehicleFields[0].(string)
+				hopOnActive, _ := vehicleFields[1].(string)
+				currentVehicleState := rawState
+				if hopOnActive == "true" {
+					currentVehicleState = "stand-by"
 				}
 
 				if currentVehicleState != lastState {

--- a/internal/events/detector.go
+++ b/internal/events/detector.go
@@ -324,7 +324,13 @@ func (d *Detector) checkConnectivityEvents(fields map[string]string) {
 func (d *Detector) checkVehicleEvents(fields map[string]string) {
 	// Vehicle state changes
 	stateKey := "vehicle:state"
+	// Apply the hop-on-active override so the cloud-facing state change
+	// event matches what telemetry reports: "parked" is externally
+	// represented as "stand-by" while hop-on is engaged.
 	state := fields["state"]
+	if fields["hop-on-active"] == "true" {
+		state = "stand-by"
+	}
 
 	d.mu.Lock()
 	lastState := d.lastState[stateKey]

--- a/internal/telemetry/priority.go
+++ b/internal/telemetry/priority.go
@@ -29,6 +29,7 @@ var PriorityNames = map[Priority]string{
 var FieldPriorities = map[string]Priority{
 	// Immediate priority - critical state changes
 	"vehicle[state]":                 Immediate,
+	"vehicle[hop-on-active]":         Immediate,
 	"vehicle[seatbox:lock]":          Immediate,
 	"vehicle[handlebar:lock-sensor]": Immediate,
 	"vehicle[blinker:state]":         Immediate,

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -132,8 +132,16 @@ func GetTelemetryFromRedis(ctx context.Context, redisClient *redis.Client, confi
 	if err != nil {
 		return nil, fmt.Errorf("failed to get vehicle state: %v", err)
 	}
+	// While vehicle[hop-on-active]=true, vehicle-service publishes state as
+	// "parked" so the dashboard's isParked() keeps working. Externally the
+	// scooter is effectively locked — report it as "stand-by" to the cloud
+	// so the mobile app offers an unlock affordance.
+	state := vehicle["state"]
+	if vehicle["hop-on-active"] == "true" {
+		state = "stand-by"
+	}
 	telemetry.VehicleState = models.VehicleState{
-		State:         vehicle["state"],
+		State:         state,
 		Kickstand:     vehicle["kickstand"],
 		SeatboxLock:   vehicle["seatbox:lock"],
 		BlinkerSwitch: vehicle["blinker:switch"],


### PR DESCRIPTION
vehicle-service publishes vehicle[state]=parked while hop-on is active (to keep the dashboard's isParked() working) and signals engagement via vehicle[hop-on-active] separately. The cloud / mobile app were seeing "parked" with no way to exit hop-on.

- Override vehicle[state] -> "stand-by" in GetTelemetryFromRedis whenever vehicle[hop-on-active]=true.
- Promote vehicle[hop-on-active] to Immediate priority so a flag flip triggers a prompt monitor flush.
- Read the effective (overridden) state in the MQTT client's pub/sub change detection so lastState tracks cloud-facing state.
- Apply the same override in the events detector's checkVehicleEvents so state-change events match telemetry.
